### PR TITLE
Testを分離し，事前にユーザデータを注入するように変更 Fixes #62

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+HOSTNAME=https://bash.chomama.jp/api

--- a/api/src/app/database/base.py
+++ b/api/src/app/database/base.py
@@ -3,12 +3,12 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from os import environ
 
-if environ['NODE_ENV'] == 'development':
+if environ['NODE_ENV'] != 'production':
     engine = create_engine(
         environ['DB_URL'],
         connect_args={"check_same_thread": False}
     )
-else:
+else:  # pragma: no cover
     engine = create_engine(
         environ['DB_URL'],
     )

--- a/api/src/app/main_fastapi.py
+++ b/api/src/app/main_fastapi.py
@@ -63,7 +63,7 @@ def custom_openapi(openapi_prefix: str):  # pragma: no cover
         return api.openapi_schema
     openapi_schema = get_openapi(
         title="Web Bash API",
-        version="v 2.0.0",
+        version="v 2.0.3",
         openapi_prefix=openapi_prefix,
         description="シェル芸 on API",
         routes=api.routes,

--- a/api/src/app/test/test_01_auth.py
+++ b/api/src/app/test/test_01_auth.py
@@ -4,6 +4,11 @@ from concurrent import futures
 from urllib.parse import urljoin
 import pytest
 import app.main_fastapi
+from app.database.crud import create_token, create_user, get_user_by_social_id, update_token
+from app.database.base import get_db
+from app.database import schemas
+from app.auth.oauth import oauth, authenticate_user, create_access_token
+from datetime import timedelta
 import asyncio
 import os
 
@@ -11,23 +16,48 @@ import os
 client = TestClient(app.main_fastapi.api)
 
 # TODO: テスト時にあらかじめTwitter Userを作っとかないとデプロイ時のテストには通らん...
-# @pytest.fixture
-# def access_token():
-#     resp = client.post('/token/', data={
-#         'oauth_token': os.environ['TWITTER_ACCESS_TOKEN'],
-#         'oauth_token_secret': os.environ['TWITTER_ACCESS_TOKEN_SECRET'],
-#     })
-#     assert resp.status_code == 200
-#     assert 'access_token' in resp.json().keys()
-#     assert 'refresh_token' in resp.json().keys()
-#     return resp.json()['access_token']
 
 
-# def test_access_user(access_token):
-#     resp = client.get('/users/me', headers={
-#         "access-token": access_token
-#     })
-#     assert resp.status_code == 200
+@pytest.fixture
+async def access_token():
+    # REGISTER Token
+    access_token_expire = timedelta(
+        minutes=int(os.environ['ACCESS_TOKEN_EXPIRE_MINUTES'])
+    )
+    db = next(get_db())
+    if (user := await authenticate_user(os.environ['TWITTER_ACCESS_TOKEN'], os.environ['TWITTER_ACCESS_TOKEN_SECRET'])):
+        access_token = create_access_token(
+            user["user_id"], access_token_expire)
+        if (db_user := get_user_by_social_id(db, user['user_id'])):
+            update_token(
+                db, db_user, access_token['refresh_token']
+            )
+        else:
+            db_user = create_user(
+                db, schemas.UserCreate(username=user["user_name"], avater_url=user["avater_url"]))
+            usertoken = create_token(db, schemas.TokenCreate(
+                social_id=user['user_id'],
+                refresh_token=access_token['refresh_token'],
+            ), owner_id=db_user.id)
+        return access_token
+    else:
+        assert False
+    # GET Token
+    resp = client.post('/token/', data={
+        'oauth_token': os.environ['TWITTER_ACCESS_TOKEN'],
+        'oauth_token_secret': os.environ['TWITTER_ACCESS_TOKEN_SECRET'],
+    })
+    assert resp.status_code == 200
+    assert 'access_token' in resp.json().keys()
+    assert 'refresh_token' in resp.json().keys()
+    return resp.json()['access_token']
+
+
+def test_access_user(access_token):
+    resp = client.get('/users/me', headers={
+        "access-token": access_token['access_token'].decode('utf-8')
+    })
+    assert resp.status_code == 200
 
 
 def test_invalid_token():

--- a/api/src/requirements.txt
+++ b/api/src/requirements.txt
@@ -20,3 +20,4 @@ itsdangerous
 pyjwt
 passlib[bcrypt]
 psycopg2
+pytest-asyncio

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,8 +16,8 @@ services:
       context: ./api
       target: PROD
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret
     environment:
       NODE_ENV: production
     working_dir: /src
@@ -45,8 +45,8 @@ services:
     image: mongo
     restart: always
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret
     volumes:
       - ./mongo_db:/data/db
   postgres:
@@ -54,7 +54,7 @@ services:
     ports:
       - 5432
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret
     volumes:
       - ./postgres:/var/lib/postgresql/data

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./frontend
       target: PROD
-    env_file: ./.env.prod
+    env_file: ./.env.test
     environment:
       NODE_ENV: production
     working_dir: /app
@@ -16,10 +16,10 @@ services:
       context: ./api
       target: PROD
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret
     environment:
-      NODE_ENV: production
+      NODE_ENV: test
       API_ENV: TEST
     working_dir: /src
     volumes:
@@ -46,8 +46,8 @@ services:
     image: mongo
     restart: always
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret
     volumes:
       - ./test/mongo:/data/db
   postgres:
@@ -55,5 +55,5 @@ services:
     ports:
       - 5432
     env_file:
-      - ./.env.prod
-      - ./.env.prod.secret
+      - ./.env.test
+      - ./.env.test.secret

--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -6,7 +6,7 @@
       padless
       cols="12"
     >
-      Version 2.0.0 |
+      Version 2.0.3 |
       &copy; {{ new Date().getFullYear() }} — <strong>FF</strong> (Twitter: <a
         target="_blank"
         href="https://twitter.com/fujifog"

--- a/test.dev.sh
+++ b/test.dev.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+rm -f ./api/src/test.sqlite
 docker-compose -f docker-compose.test.yml run --entrypoint 'pytest -v --cov=app --cov-report xml --cov-report html --cov-report term-missing' api

--- a/test.prod.sh
+++ b/test.prod.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm -f ./api/src/test.sqlite
 echo '[*] Down Docker Container'
 docker-compose -f docker-compose.test.yml down --remove-orphans
 echo '[*] Build Images'


### PR DESCRIPTION
## 関連するIssue

Fixes #62 

## 修正の程度

- [ ] 破壊的で刷新的な新機能
- [ ] 軽微な新機能
- [ ] バグ修正
- [x] 軽微な修正

## 概要

テスト時に逐一データを削除し，APIにTwitterデータを注入してアクセストークンの取得を行えるように設定した

## 変更点

- [x] `pytest-asyncio`の追加
- [x] アクセストークンの取得テストの追加
- [x] Docker-Composeの設定をテスト用に分離

